### PR TITLE
Update README to avoid error on route in Sinatra

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,8 +106,10 @@ map '/' do
   run Sample::App.new
 end
 
-map '/inbox' do
-  run Goatmail::App.new
+if ENV['RACK_ENV'] == 'development'
+  map '/inbox' do
+    run Goatmail::App.new
+  end
 end
 ```
 


### PR DESCRIPTION
Since Goatmail is only available in development, if you mount the route
`/inbox` in other environment it will generate an error

```
config.ru:in `block (2 levels) in <main>':
  uninitialized constant Goatmail (NameError)
```

This fixes the instructions on how to mount the route properly.