### PR TITLE
Fix #deliver!  method

### DIFF
--- a/goatmail.gemspec
+++ b/goatmail.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.0.0'
 
-  spec.add_dependency "letter_opener"
+  spec.add_dependency "letter_opener", '>= 1.5.0'
   spec.add_dependency "sinatra"
 
   spec.add_development_dependency "bundler", "~> 1.6"


### PR DESCRIPTION
 letter_opener gemのアップデートの影響で、`deliver!`メソッド内でエラーが起こっていたのを修正しました。

■対象の変更
https://github.com/ryanb/letter_opener/commit/e5fbf0f231d60e539ee8ddae4144226af63a4065#diff-3fd72a58a89598da81e1cffbb6fdfb2aR30

■変更内容
* `LetterOpener::Message.rendered_messages`について引数をletter_openerの順番にあわせました
*  継承している `DeliveryMethod#initialize`で`Goatmail.location`を`settings[:location]`に設定するようにしました
* letter_openerのバージョン指定をv 1.5.0以上を指定するように変更しました